### PR TITLE
chore: clearer justification on signalment

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,7 @@ en:
       locked: Your account is locked, check your emails to get unlock instructions
     spam_signal:
       spam_signal_justification: |
-        The spam filter have identified a spamming content.
+        Antispam hide this content as the author or the content itself looks suspicious
       errors:
         spam: Your comment looks like spam.
       forms:


### PR DESCRIPTION
Provide a better justification on signalment for admins: they may face hidden content that seems legit at first, but comes from a suspicious user.