### PR TITLE
Fix: copbot email @example.org

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,7 @@ en:
       locked: Your account is locked, check your emails to get unlock instructions
     spam_signal:
       spam_signal_justification: |
-        The spam filter have identified a spamming content.
+        Antispam hide this content as the author or the content itself looks suspicious
       errors:
         spam: Your comment looks like spam.
       forms:

--- a/db/migrate/20230920151920_copbot_email.rb
+++ b/db/migrate/20230920151920_copbot_email.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CopbotEmail < ActiveRecord::Migration[5.2]
+  def change
+    # bot email should never be bot@decidim.org
+    cop = Decidim::User.where(nickname: "bot").first
+    cop.update(email: ENV.fetch("USER_BOT_EMAIL", "bot@example.org"))
+    Decidim::User.where(email: "bot@decidim.org").each |legacy_bot|
+      legacy_bot.destroy
+    end
+  end
+end

--- a/lib/decidim/spam_signal/cop_bot.rb
+++ b/lib/decidim/spam_signal/cop_bot.rb
@@ -14,10 +14,12 @@ module Decidim
           usr.confirmed_at = ::Time.current
           usr.locale = ::I18n.default_locale
           usr.admin = true
-
+          usr.email_on_moderations = false
           usr.tos_agreement = true
           usr.personal_url = ""
           usr.about = ""
+          usr.notification_types = "none"
+          usr.email_on_notification = false
           usr.accepted_tos_version = organization.tos_version
           usr.admin_terms_accepted_at = ::Time.current
         end
@@ -26,6 +28,9 @@ module Decidim
           email: ENV.fetch("USER_BOT_EMAIL", "bot@example.org"),
           confirmed_at: ::Time.current,
           admin: true,
+          email_on_moderations: false,
+          email_on_notification: false,
+          notification_types: "none",
           accepted_tos_version: organization.tos_version,
           admin_terms_accepted_at: ::Time.current
         )

--- a/lib/decidim/spam_signal/cop_bot.rb
+++ b/lib/decidim/spam_signal/cop_bot.rb
@@ -4,12 +4,11 @@ module Decidim
   module SpamSignal
     class CopBot
       def self.get(organization)
-        suffixe = Decidim::User.where(nickname: "bot").count
         user_bot = Decidim::User.find_or_create_by!(
-          email: ENV.fetch("USER_BOT_EMAIL", "bot@example.org")
+          nickname: "bot"
         ) do |usr|
           usr.name = "bot"
-          usr.nickname = "bot#{suffixe if suffixe > 0}"
+          usr.email = ENV.fetch("USER_BOT_EMAIL", "bot@example.org")
           usr.password = usr.password_confirmation = ::Devise.friendly_token
           usr.organization = organization
           usr.confirmed_at = ::Time.current

--- a/lib/decidim/spam_signal/cop_bot.rb
+++ b/lib/decidim/spam_signal/cop_bot.rb
@@ -23,6 +23,8 @@ module Decidim
         end
         user_bot.update(
           blocked: false,
+          email: ENV.fetch("USER_BOT_EMAIL", "bot@example.org"),
+          confirmed_at: ::Time.current,
           admin: true,
           accepted_tos_version: organization.tos_version,
           admin_terms_accepted_at: ::Time.current


### PR DESCRIPTION
copbot should never use `@decidim.org` email. 

* Get copbot by `nickname` and not by email. (ensure uniqueness).
* Do not subscribe to moderation or any notifications
* Add a migration to move old cop bot to this new strategy
* Remove old copbot instance.