### PR TITLE
fix: migration fails when first run

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,10 @@ en:
       decidim/spam_signal/config:
         one: "Anti-Spam Configuration"
         other: "Anti-Spam Configurations"
-
+  devise:
+    failure:
+      locked:  |
+        Your account is locked, check your emails to get unlock instructions
   activemodel:
     attributes:
       lock:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -10,6 +10,10 @@ fr:
       locked:  |
         Votre compte à été bloqué par notre système, veuillez consulter nos termes et conditions ici: 
         /pages/terms-and-conditions
+  activemodel:
+    attributes:
+      lock:
+        is_email_unlockable: "Permettre de déverouiller le compte par email"
   decidim:
     account:
       locked:  |

--- a/db/migrate/20230920151920_copbot_email.rb
+++ b/db/migrate/20230920151920_copbot_email.rb
@@ -4,9 +4,11 @@ class CopbotEmail < ActiveRecord::Migration[5.2]
   def change
     # bot email should never be bot@decidim.org
     cop = Decidim::User.where(nickname: "bot").first
-    cop.email = ENV.fetch("USER_BOT_EMAIL", "bot@example.org")
-    cop.skip_confirmation!
-    cop.save
+    if cop
+      cop.email = ENV.fetch("USER_BOT_EMAIL", "bot@example.org")
+      cop.skip_confirmation!
+      cop.save
+    end
     Decidim::User.where(email: "bot@decidim.org").each do |legacy_bot|
       Decidim::UserReport.where(user: legacy_bot).update(user: cop)
       legacy_bot.destroy


### PR DESCRIPTION
Fix a bug introduced by a v2.0.0 migration when installing the gem for the first time.

`db/migrate/20230921093701_copbot_email.decidim_spam_signal.rb` will takes the last bot user to update it, but when running for the first time, the bot user doesn't exists. 